### PR TITLE
🏗️✨ add lint-and-test workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,53 @@
+name: Lint and test
+
+# By default, runs when a pull request is opened, synchronized, or reopened.
+on: pull_request
+
+jobs:
+  lint_and_test:
+    name: Lint and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1.0.0
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install
+        run: npm ci
+
+      # Checks to see if any files in the PR match one of the listed file types.
+      # We can use this filter to decide whether or not to run linters or tests.
+      # You can check if a file with a listed file type is in the PR by doing:
+      # if: ${{ steps.filter.outputs.md == 'true' }}
+      # This will return true if there's a Markdown file the PR has changed.
+      - uses: dorny/paths-filter@v2.2.1
+        id: filter
+        with:
+          filters: |
+            css:
+              - '**/*.css'
+            js:
+              - '**/*.js'
+            json:
+              - '**/*.json'
+            md:
+              - '**/*.md'
+            njk:
+              - '**/*.njk'
+            svg:
+              - '**/*.svg'
+            yml:
+              - '**/*.yml'
+
+      - name: Test
+        if: ${{ steps.filter.outputs.css == 'true' || steps.filter.outputs.js == 'true' || steps.filter.outputs.json == 'true' || steps.filter.outputs.md == 'true' || steps.filter.outputs.njk == 'true' || steps.filter.outputs.svg == 'true' || steps.filter.outputs.yml == 'true' }}
+        run: npm run test


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow for linting and testing the various filetypes we currently verify. Once tests have been added, the distinction between linting and testing will be made, at which point the filtering will be leveraged to a greater extent.