### PR TITLE
📖+🏗️🔧 get Markdown linter working and make flagged corrections

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -58,7 +58,7 @@ var naturalLanguage = unified().use([
   ],
 ]);
 
-module.exports.default = {
+module.exports = {
   plugins: [
     require('remark-lint'),
     // Leave this preset at the top so that it can be overridden.

--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -54,7 +54,7 @@ var naturalLanguage = unified().use([
   require('retext-syntax-mentions'),
   [
     require('retext-spell'),
-    { dictionary: require('dictionary-en-gb'), personal: personal },
+    { dictionary: require('dictionary-en'), personal: personal },
   ],
 ]);
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,10 @@ Once you have identified an issue you would like to work on, follow these steps:
     submit your PR.
 4.  Wait for code review and address any issues raised as soon as you can.
 
-Even if you are not done with the issue, create a [draft pull request] and push
-your code [early and often][]. If we haven't heard from you in over a week and
-someone else expresses interest in that issue, we may approve the new person's
-work.
+Even if you are not done with the issue, create a [draft pull request][] and
+push your code [early and often][]. If we haven't heard from you in over a week
+and someone else expresses interest in that issue, we may approve the new
+person's work.
 
 ### Opening a new issue
 
@@ -62,7 +62,7 @@ details and the rationale for the proposed change.
 
 ## Pull requests
 
-If you'd like to propose and collaborate on changes, open a [pull request]!
+If you'd like to propose and collaborate on changes, open a [pull request][]!
 
 Here are a few things you can do that will increase the likelihood of having
 your pull request merged:
@@ -72,7 +72,7 @@ your pull request merged:
 - Keep your change as focused as possible. If there are multiple changes you
   would like to make that are not dependent upon each other, consider submitting
   them as separate pull requests.
-- Write a [good commit message].
+- Write a [good commit message][].
 
 Contributions to this project are [released][contrib-license] to the public
 under the project’s open source license. The license for a project is located in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ This project uses the following tools to organize discussion.
 ## Issue tracker
 
 If you've found a bug, would like to request a new feature or make a proposal,
-file an [issue]!
+file an [issue][]!
 
 ### Resolving open issues
 
@@ -27,8 +27,8 @@ repository, and that’s where you can find tasks to undertake. First, check the
 labels on the issue you're interested in.
 
 - Issues labeled _help wanted_ or _good first issue_ have been identified as
-  desirable for community contribution. Feel free to work on GFIs even if it is
-  not your first issue.
+  desirable for community contribution. Feel free to work on GFIs even if not
+  your first issue.
   - List of [all issues labeled _good first issue_][i-gfi]
   - List of [all issues labeled _help wanted_][i-help]
   - List of [all incomplete pull requests labeled _help wanted_][pr-help]
@@ -49,7 +49,7 @@ Once you have identified an issue you would like to work on, follow these steps:
 4.  Wait for code review and address any issues raised as soon as you can.
 
 Even if you are not done with the issue, create a [draft pull request] and push
-your code [early and often]. If we haven't heard from you in over a week and
+your code [early and often][]. If we haven't heard from you in over a week and
 someone else expresses interest in that issue, we may approve the new person's
 work.
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1,1 +1,5 @@
-# TODO
+changelog
+freenode
+GFIs
+OpenINF
+SDK

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/plugin-syntax-top-level-await": "7.12.1",
     "@babel/preset-env": "7.12.1",
     "@yarnpkg/shell": "2.4.0",
-    "dictionary-en-gb": "2.2.2",
+    "dictionary-en": "3.0.1",
     "editorconfig-checker": "3.3.0",
     "eslint": "7.13.0",
     "eslint-config-prettier": "6.15.0",


### PR DESCRIPTION
I took the silence to mean that there were no problems w/ these documents when in reality the Markdown linter was misconfigured (sorry!). This PR does not correct all of the warnings flagged. I am still deliberating about whether or not curly (smart) quotes should be allowed or not. The other warnings are silly and can be ignored, so a way to suppress those still needs to be discovered.