### PR TITLE
ℹ️🚮 remove unnecessary package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,4 @@
 {
-  "private": "true",
-  "name": "root0",
-  "version": "0.0.0",
-  "description": "The OpenINF website and other static resources",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/openinf/openinf.github.io.git"
-  },
-  "keywords": [],
-  "author": "The OpenINF Authors",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/openinf/openinf.github.io/issues"
-  },
-  "homepage": "https://github.com/openinf/openinf.github.io#readme",
   "engines": {
     "node": ">=14.15.0"
   },


### PR DESCRIPTION
All of these fields are for use by npm and we have no reason to have this specified here since this isn't a package.

I am leaving `engines.node` since the [`eslint-plugin-node`](https://www.npmjs.com/package/eslint-plugin-node) (specifically the `node/no-unsupported-features/es-syntax` rule) and other tools make use of it. We can re-evaluate the utility of it once this site is finalized.