### PR TITLE
Revert "ℹ️🚮 remove unnecessary package metadata"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,19 @@
 {
+  "private": "true",
+  "name": "root0",
+  "version": "0.0.0",
+  "description": "The OpenINF website and other static resources",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openinf/openinf.github.io.git"
+  },
+  "keywords": [],
+  "author": "The OpenINF Authors",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/openinf/openinf.github.io/issues"
+  },
+  "homepage": "https://github.com/openinf/openinf.github.io#readme",
   "engines": {
     "node": ">=14.15.0"
   },


### PR DESCRIPTION
Reverts openinf/openinf.github.io#28

Although it's true, further deliberation is necessary.