### PR TITLE
🏗️🔧 add support for JEKYLL_GITHUB_TOKEN env var

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,6 @@ gem "wdm", "0.1.1", :install_if => Gem.win_platform?
 gem 'yaml-lint', '0.0.10'
 
 gem "webrick", "1.7.0"
+
+# Fix for https://github.com/github/pages-gem/issues/399.
+gem 'dotenv'


### PR DESCRIPTION
> The `jekyll-github-metadata` gem is automatically enabled for GitHub Pages builds (including builds using this gem locally). It pulls in information from the GitHub API, but [first checks the environment for authentication, which is required for some API calls to return the data we want](https://github.com/jekyll/github-metadata/blob/8906f2b9c890f0aafef96423c7cd7e5047f7dae4/lib/jekyll-github-metadata/client.rb#L96-L97). It's a warning, not an error, so you should be good to ignore them locally. 👍
> &mdash; https://github.com/github/pages-gem/issues/399#issuecomment-280186771

---

> "GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data."
>
> To create a personal access token: (public_repo scope is enough for public repository): https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token

Refs: https://github.com/github/pages-gem/issues/399