### PR TITLE
fix(conf): reset to use correct excluded files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,11 +61,7 @@ exclude:
   - Gemfile.lock
   - node_modules/
   - package.json
+  - package-lock.json
   - README.md
   - tmp/
   - vendor/
-  - CONTRIBUTING.md
-  - CODE_OF_CONDUCT.md
-  - SECURITY.md
-  - SUPPORT.md
-  - VISION.md

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ email: code@open.inf.is
 description: >-
   Aggregate, curate, disseminate, and apply information derived from diverse
   sources.
-baseurl: ""
-url: "https://open.inf.is"
+baseurl: ''
+url: 'https://open.inf.is'
 twitter_username: openinf
 github_username: openinf
 repository: openinf/openinf.github.io
@@ -37,10 +37,10 @@ collections:
   authors:
     output: true
   docs:
-    permalink: "/:collection/:path/"
+    permalink: '/:collection/:path/'
     output: true
   posts:
-    permalink: "/news/:year/:month/:day/:title/"
+    permalink: '/news/:year/:month/:day/:title/'
     output: true
 defaults:
   - scope:


### PR DESCRIPTION
This list of excluded files needed to be updated to no longer include the community health files, which have moved to the dotrepo. The issues template is still referencing the current location of the CONTRIBUTING file, which also needs to be updated as well, but we'll start off doing this first.

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is