### PR TITLE
🏗️🔧：clean prior to build portal

### DIFF
--- a/build/tasks/compile/build-portal.mts
+++ b/build/tasks/compile/build-portal.mts
@@ -5,7 +5,8 @@
  * @module {type ES6Module} build/tasks/compile/build-portal
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
+import { PATHS } from '@openinf/portal/build/constants';
 import { exec } from '@openinf/portal/build/utils';
 
 let exitCode = 0;
@@ -19,6 +20,11 @@ const scripts = [
 if (!existsSync('collections/_docs/support.md')) {
   scripts.unshift('nps compile.siteifyHealthFiles');
 }
+
+// Normally the site dir is auto-cleaned by Jekyll, but if we don't
+// clean it ourselves using Node, it produces unlink errors from Ruby.
+if (existsSync(PATHS.siteDir))
+  rmSync(PATHS.siteDir, { recursive: true, force: true });
 
 for (const element of scripts) {
   exitCode = await exec(element);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/OpenINF/.github/blob/HEAD/CONTRIBUTING.md.

# Instructions

- Pick a meaningful title for your pull request.
  (Use sentence case.)
  - Prefix the title with an emoji to identify
    what is being done. (Copy-paste the emoji
    from the list below.)
  - Do not overuse punctuation in the title
    (like `(chore):`).
  - If it is helpful, use a simple prefix (like
    `ProjectX: Implement some feature`).
- Enter a succinct description that says why the
  PR is necessary, and what it does.
  - Mention the GitHub issue that is being
    addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves`
    followed the issue number will automatically
    close the issue.

> NOTE: All non-trivial changes (like introducing
> new features or components) should have an
> associated issue.

## Example of a good description

- implement aspect X
- leave out feature Y because of A
- improve performance by B
- improve accessibility by C

## Emojis for categorizing pull requests

_Copy and paste one of the following emoji into description_

🏷️ meta
🐋 dev container
🧩 extension ∥ plugin
🏗️ infrastructure ∥ tooling ∥ builds ∥ CI/CD
⚕️ community health files (CODE_OF_CONDUCT,
CONTRIBUTING, SUPPORT, VISION, etc.)
🧪 tests
❄️ flaky tests
💄 CSS ∥ styling
♿ accessibility
🌐 internationalization
📖 documentation
📦 packages & package management

Follow it by one of the following actions (or leave it unscoped).

✨ new feature
🔧 bug fix
🔥 P0 fix
🚀 performance improvements
⏪ reverting a previous change
♻️ refactoring
🚮 deleting code
🥼 experimental code

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

as the comment states, we are now cleaning the site dir prior to jekyll building since it was causing unlink errors..